### PR TITLE
Add cmake, re-add solution counter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 *.exe
 *.out
 *.app
+
+# Build folder
+build/
+
+# Output files
+BullyPositions.txt

--- a/BullyPath.cpp
+++ b/BullyPath.cpp
@@ -1,3 +1,6 @@
+#include <cmath>
+#include <cstdint>
+
 #include "BullyPath.hpp"
 #include "SpeedRangeSearch.hpp"
 #include "Trig.hpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,4 +12,5 @@ add_executable(bruteforce
   Constants.hpp
   BullyPath.cpp
   BullyPath.hpp
+  Int128.hpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.15)
+project(sm64_bully_movement
+  DESCRIPTION "Bruteforces bully speed/angle combinations for triple-bully-collision displacement"
+)
+
+add_executable(bruteforce
+  main.cpp
+  Trig.cpp
+  Trig.hpp
+  SpeedRangeSearch.cpp
+  SpeedRangeSearch.hpp
+  Constants.hpp
+  BullyPath.cpp
+  BullyPath.hpp
+)

--- a/Int128.hpp
+++ b/Int128.hpp
@@ -1,0 +1,21 @@
+#ifndef INT128_HPP
+#define INT128_HPP
+
+#include <algorithm>
+#include <string>
+
+using int128_t = __int128;
+using uint128_t = unsigned __int128;
+
+inline std::string to_string(uint128_t x) {
+  std::string out;
+  out.reserve(40);
+  while (x > 0) {
+    out.push_back((x % 10) | 0x30);
+    x /= 10;
+  }
+  std::reverse(out.begin(), out.end());
+  return out;
+}
+
+#endif

--- a/SpeedRangeSearch.cpp
+++ b/SpeedRangeSearch.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 #include "Constants.hpp"
 #include "SpeedRangeSearch.hpp"
 #include "Trig.hpp"

--- a/main.cpp
+++ b/main.cpp
@@ -1,9 +1,12 @@
 #include <iostream>
 #include <fstream>
+#include <cmath>
+
 #include "BullyPath.hpp"
 #include "Constants.hpp"
 #include "SpeedRangeSearch.hpp"
 #include "Trig.hpp"
+
 
 ofstream out_stream;
 

--- a/main.cpp
+++ b/main.cpp
@@ -6,9 +6,12 @@
 #include "Constants.hpp"
 #include "SpeedRangeSearch.hpp"
 #include "Trig.hpp"
+#include "Int128.hpp"
 
 
 ofstream out_stream;
+uint128_t counter = 0;
+
 
 void build_path(BullyPath &path, int n_frames, int total_frames, float max_offset) {
 	float base_dist = path.calculate_current_dist();
@@ -25,7 +28,12 @@ void build_path(BullyPath &path, int n_frames, int total_frames, float max_offse
 				//Output solution
 				#pragma omp critical 
 				{
-					out_stream << n_frames << "," << path.start_yaw << "," << fixed << path.start_position[0] << "," << fixed << path.start_position[1] << "," << fixed << path.start_position[2] << "," << fixed << path.speed_ranges[i].first << "," << fixed << path.speed_ranges[i].second << "," << fixed << (base_dist*path.speed_ranges[i].first) << "," << fixed << (base_dist*path.speed_ranges[i].second) << "\n";
+					out_stream << n_frames << "," << path.start_yaw << "," << fixed << path.start_position[0] << "," 
+            << fixed << path.start_position[1] << "," << fixed << path.start_position[2] << "," 
+            << fixed << path.speed_ranges[i].first << "," << fixed << path.speed_ranges[i].second << "," 
+            << fixed << (base_dist*path.speed_ranges[i].first) << "," 
+            << fixed << (base_dist*path.speed_ranges[i].second) << "\n";
+          counter++;
 				}
 			}
 		}
@@ -361,6 +369,8 @@ int main()
 	out_stream.open("BullyPositions.txt");
 
 	find_paths(start_position, min_speed, max_speed, total_frames, max_offset);
-
-	out_stream.close();
+  
+  // RAII will autoclose out_stream, no need to worry about it
+	// out_stream.close();
+  cout << "Found " << to_string(counter) << " solutions" << endl;
 }


### PR DESCRIPTION
I'm pretty sure that the 128-bit counter won't ever overflow.

Also, cmake so that we can get Miranda's DB setup on this later. Should be simple to setup via CMake packages.