### PR TITLE
fixing typo in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ main: BullyPath.o SpeedRangeSearch.o Trig.o main.o
 	$(CXX) $(CXXFLAGS) -o main BullyPath.o SpeedRangeSearch.o Trig.o main.o $(LDFLAGS)
 
 clean:
-	*.o main
+	rm -f *.o main


### PR DESCRIPTION
Not making so many paths and reusing them so we don't spend so much time in malloc and free.

timed by changing max_speed to 10000000.0f;
took 38 seconds before the change and 24 seconds afterwards 